### PR TITLE
Update First Page Links to use FirstText param

### DIFF
--- a/src/BlazorPager.razor
+++ b/src/BlazorPager.razor
@@ -32,11 +32,11 @@
             {
                 if (CurrentPage == 1)
                 {
-                    <li class="page-item disabled noselect"><a class="page-link" tabindex="-1"><span aria-hidden="true">&laquo;</span><span class="sr-only">@FirstText</span></a></li>
+                    <li class="page-item disabled noselect"><a class="page-link" tabindex="-1"><span aria-hidden="true">@FirstText</span><span class="sr-only">Go to first page</span></a></li>
                 }
                 else
                 {
-                    <li class="page-item noselect"><a class="page-link sort-link" @onclick="@(() => PagerButtonClicked(1))"><span aria-hidden="true">&laquo;</span><span class="sr-only">@FirstText</span></a></li>
+                    <li class="page-item noselect"><a class="page-link sort-link" @onclick="@(() => PagerButtonClicked(1))"><span aria-hidden="true">@FirstText</span><span class="sr-only">Go to first page</span></a></li>
                 }
             }
             @if (hasPrevious)


### PR DESCRIPTION
Currently the First Page link is hard coded to &laquo;. This change removes that and uses the FirstText param to set the text. The sr-only text was changed to match the text in the last page sr-only text.